### PR TITLE
Fix link icon size

### DIFF
--- a/components/shared/CustomMarkdown/Markdown.styles.ts
+++ b/components/shared/CustomMarkdown/Markdown.styles.ts
@@ -70,5 +70,6 @@ export const LinkIcon = styled.div`
 
   svg {
     color: #777;
+    width: 18px;
   }
 `;


### PR DESCRIPTION
**before**

<img width="208" alt="Screen Shot 2021-09-30 at 2 55 47 PM" src="https://user-images.githubusercontent.com/206753/135535421-f29538a0-5193-47f6-b9f8-4397c8b9cb1f.png">

**after**

<img width="185" alt="Screen Shot 2021-09-30 at 2 55 04 PM" src="https://user-images.githubusercontent.com/206753/135535431-937e7a84-2d10-458d-98b2-501b38f6206e.png">


