### PR TITLE
Blur solutions code blocks by default

### DIFF
--- a/components/shared/CustomMarkdown/CodeBlock/index.tsx
+++ b/components/shared/CustomMarkdown/CodeBlock/index.tsx
@@ -1,0 +1,70 @@
+import React, {useState} from 'react';
+import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
+import {dracula} from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import styled from 'styled-components';
+
+const CodeBlock = ({codeStr, language}: {codeStr: any; language: any}) => {
+  const [showCode, setShowCode] = useState<boolean>(false);
+
+  return (
+    <RevealWrapper>
+      {!showCode && (
+        <Reveal onClick={() => setShowCode(true)}>Show Solution</Reveal>
+      )}
+      <CodeBlockWrapper showCode={showCode}>
+        {!showCode && <Overlay />}
+        <SyntaxHighlighter
+          language={language}
+          PreTag="div"
+          customStyle={{margin: '1.5em 0'}}
+          style={dracula}
+        >
+          {codeStr}
+        </SyntaxHighlighter>
+      </CodeBlockWrapper>
+    </RevealWrapper>
+  );
+};
+
+const CodeBlockWrapper = styled.div<{showCode: boolean}>`
+  position: relative;
+  filter: ${({showCode}) => (showCode ? 'blur(0)' : 'blur(6px)')};
+`;
+
+const Overlay = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+const RevealWrapper = styled.div`
+  position: relative;
+`;
+
+const Reveal = styled.div`
+  position: absolute;
+  color: white;
+  z-index: 100;
+  display: flex;
+
+  /* button */
+  border: solid 1px white;
+  padding: 4px 10px;
+  cursor: pointer;
+  border-radius: 3px;
+  &:hover {
+    background: #555;
+  }
+
+  /* center */
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 30px;
+  left: 0;
+  right: 0;
+  width: 130px;
+`;
+
+export default CodeBlock;

--- a/components/shared/CustomMarkdown/index.tsx
+++ b/components/shared/CustomMarkdown/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
 import {dracula} from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import gfm from 'remark-gfm';
 import {Typography, Divider, Tag} from 'antd';
@@ -9,6 +8,7 @@ import {FileOutlined, LinkOutlined} from '@ant-design/icons';
 import {extractStringFromTree, stringToCssId} from './utils/string-utils';
 import {GitbookHintType, gitbookHintTypeToAntd} from './utils/markdown-utils';
 import VideoPlayer from './VideoPlayer';
+import CodeBlock from './CodeBlock';
 
 import {
   StyledListItem,
@@ -39,15 +39,10 @@ const Markdown = ({
         code({node, inline, className, children, ...props}) {
           const match = /language-(\w+)/.exec(className || '');
           return !inline && match ? (
-            <SyntaxHighlighter
+            <CodeBlock
               language={match[1]}
-              PreTag="div"
-              customStyle={{margin: '1.5em 0'}}
-              style={dracula}
-              {...props}
-            >
-              {String(children).replace(/\n$/, '')}
-            </SyntaxHighlighter>
+              codeStr={String(children).replace(/\n$/, '')}
+            />
           ) : (
             <Text code>{children}</Text>
           );

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/depd": "^1.1.32",
     "@types/jest": "^27.0.1",
     "@types/mz": "^2.7.4",
+    "@types/react-syntax-highlighter": "^13.5.2",
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "babel-jest": "^27.2.0",
     "babel-plugin-styled-components": "^1.13.1",


### PR DESCRIPTION
![Screen Recording 2021-09-30 at 04 49 41 PM](https://user-images.githubusercontent.com/206753/135545627-81d8cd60-dd71-4d29-861b-5f691ae0ac76.gif)

@silentlight can you help me finish this? Currently this applies to all code blocks and i'd like to only have it apply for code blocks that i flas as such. Once we have this flag in the markdown (not sure how) it's easy to propagate in the component and conditionally render the blur + button

You've spent some time figuring out how to parse the markdown so you might know! thanks