### PR TITLE
switch back to semantic version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6074,7 +6074,7 @@ fbjs@^3.0.0:
     object-assign "^4.1.0"
     promise "^7.1.1"
     setimmediate "^1.0.5"
-    ua-parser-js "0.7.28"
+    ua-parser-js "^1.0.2"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
A new version of ua-parser has been released and I no longer get a package not found error when using the semantic version.

Previous Issue: https://github.com/figment-networks/learn-web3-dapp/issues/138
Previous PR: https://github.com/figment-networks/learn-web3-dapp/pull/139