### PR TITLE
Add Gitpod Workspace URL instructions to The Graph Pathway

### DIFF
--- a/markdown/the_graph/SUBGRAPH_MAPPINGS.md
+++ b/markdown/the_graph/SUBGRAPH_MAPPINGS.md
@@ -150,23 +150,17 @@ yarn create-local
 yarn deploy-local
 ```
 
-<<<<<<< Updated upstream
-What does those two commands do?
-
-- # `yarn create-local` will create an endpoints for our subgraph: here `http://localhost:8000/subgraphs/name/punks
-
-  What do those two commands do?
+What do those two commands do?
 
 - `yarn create-local` will create an endpoint for our subgraph (see the environment variable **NEXT_PUBLIC_LOCAL_SUBGRAPH** in your `.env.local`):
   - On `http://localhost:8000/subgraphs/name/punks` if running `learn-web3-dapp` locally
-  - On Gitpod, the port number goes in front of the URL like this example: `https://8000-apricot-piranha-iub1loby.ws-us18.gitpod.io/`. Your URL will be different, so you need to copy and paste it, then add the port number and hyphen in front of the URL (`8000-`) into `.env.local` as the value of **NEXT_PUBLIC_LOCAL_SUBGRAPH**.
-    > > > > > > > Stashed changes
-- `yarn deploy-local` will deploy the subgraph to those endpoints
+  - On Gitpod, the port number goes in front of the URL like this example: `https://8000-apricot-piranha-iub1loby.ws-us18.gitpod.io/`. Your URL will be different, so you need to copy and paste it from your address bar, then add the port number and hyphen in front of the URL (`8000-`) into `.env.local` as the value of **NEXT_PUBLIC_LOCAL_SUBGRAPH**.
+- `yarn deploy-local` will deploy the subgraph to the endpoint specified by **NEXT_PUBLIC_LOCAL_SUBGRAPH**.
 
-As soon as you run `yarn deploy-local` you will see Docker starting to scan the Ethereum mainnet for punks!
+As soon as you run `yarn deploy-local`, you will see Docker starting to scan the Ethereum mainnet for CryptoPunks!
 
 ![terminal](https://raw.githubusercontent.com/figment-networks/learn-web3-dapp/main/markdown/__images__/the-graph/mapping-01.gif)
 
 ## ✅ Make sure it works
 
-Now it's time for you to verify that you have followed the instructions carefully. Click on the **Check mappings** button on the right to check that your mappings are correctly implemented.
+Now it's time for you to verify that you have followed the instructions carefully. Click on the **Check subgraph deployment** button on the right to check that your mappings are correctly implemented.

--- a/markdown/the_graph/SUBGRAPH_MAPPINGS.md
+++ b/markdown/the_graph/SUBGRAPH_MAPPINGS.md
@@ -150,9 +150,17 @@ yarn create-local
 yarn deploy-local
 ```
 
+<<<<<<< Updated upstream
 What does those two commands do?
 
-- `yarn create-local` will create an endpoints for our subgraph: here `http://localhost:8000/subgraphs/name/punks
+- # `yarn create-local` will create an endpoints for our subgraph: here `http://localhost:8000/subgraphs/name/punks
+
+  What do those two commands do?
+
+- `yarn create-local` will create an endpoint for our subgraph (see the environment variable **NEXT_PUBLIC_LOCAL_SUBGRAPH** in your `.env.local`):
+  - On `http://localhost:8000/subgraphs/name/punks` if running `learn-web3-dapp` locally
+  - On Gitpod, the port number goes in front of the URL like this example: `https://8000-apricot-piranha-iub1loby.ws-us18.gitpod.io/`. Your URL will be different, so you need to copy and paste it, then add the port number and hyphen in front of the URL (`8000-`) into `.env.local` as the value of **NEXT_PUBLIC_LOCAL_SUBGRAPH**.
+    > > > > > > > Stashed changes
 - `yarn deploy-local` will deploy the subgraph to those endpoints
 
 As soon as you run `yarn deploy-local` you will see Docker starting to scan the Ethereum mainnet for punks!

--- a/markdown/the_graph/SUBGRAPH_QUERY.md
+++ b/markdown/the_graph/SUBGRAPH_QUERY.md
@@ -4,19 +4,11 @@ After deploying the subgraph, we need to wait a little in order for it to sync w
 
 We can follow the progression of the sync looking at the logged output by the running docker instance of our local graph node.
 
-<<<<<<< Updated upstream
+> Before running the query, you'll need to make sure you have the [Metamask](https://metamask.io/) extension installed in your browser and that you're connected to the mainnet of Ethereum. Why? We'll decorate the data returned by the GraphQL query with data coming from the [CryptoPunks Data on Etherscan](https://etherscan.io/address/0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2#readContract) to be able to render the images and other CryptoPunk metadata.
 
-> Before, running the query you'll need to check you have a [metamask](https://metamask.io/) extension installed with your browser and you're connected to the mainnet of Ethereum. Why? We'll decorate the date returned by the GraphQL query with data coming from the [CryptoPunks Data](https://etherscan.io/address/0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2#readContract) to be able to render the images and other punk metadata.
+Our Graph node comes with a GraphQL endpoint, available at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks/graphql) (Or at your Gitpod Workspace URL). Open this in another tab, and you will see a GraphiQL UI. Consider this a sandbox in which to experiment with GraphQL queries. Open the right sidebar to explore your schema.
 
-# Our Graph node come up with a GraphQL endpoint, available at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks/graphql). Open this in another tab and you will see a GraphiQL UI. Consider this a sandboz in which to experiment with queries. Open the right sidebar to explore your schema.
-
-> Before, running the query you'll need to check you have a [metamask](https://metamask.io/) extension installed with your browser and you're connected to the mainnet of Ethereum. Why? We'll decorate the data returned by the GraphQL query with data coming from the [CryptoPunks Data](https://etherscan.io/address/0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2#readContract) to be able to render the images and other punk metadata.
-
-Our Graph node comes with a GraphQL endpoint, available at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks/graphql). Open this in another tab and you will see a GraphiQL UI. Consider this a sandbox in which to experiment with queries. Open the right sidebar to explore your schema.
-
-If you're running the Pathway using Gitpod, you will need to add the Gitpod Workspace URL to `.env.local` instead of localhost. The port number must also be added to the beginning of the URL, rather than at the end. For example: `https://8000-olive-meerkat-mapxxnyp.ws-us18.gitpod.io/`.
-
-> > > > > > > Stashed changes
+If you're running the Pathway using Gitpod, you will need to add the Gitpod Workspace URL to `.env.local` instead of localhost, as mentioned in the previous step. The port number must also be added to the beginning of the URL, rather than at the end. For example: `https://8000-olive-meerkat-mapxxnyp.ws-us18.gitpod.io/`.
 
 ## 👨‍💻 Your turn! Write the GraphQL query
 
@@ -28,12 +20,7 @@ Some hints to help you:
 - You will want `id`, `index`, `value` and `date`
 - Then use `first`, `orderBy` and `orderDirection` to get 10 of highest value
 
-<<<<<<< Updated upstream
-Remember to use **GraphiQL IDE** at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks) to play around
-=======
 Remember to use **GraphiQL IDE** at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks) (or at your Gitpod URL) to play around
-
-> > > > > > > Stashed changes
 
 ## 😅 Solution
 
@@ -64,11 +51,6 @@ Now, it's time to enjoy the result of your work! Click on the button on the righ
 
 Nice, you made it! What did you think?
 
-<<<<<<< Updated upstream
-If you have any feedback, reach out on [Discord](https://discord.com/invite/fszyM7K)!
-=======
 If you have any feedback, reach out on [Discord](https://figment.io/devchat)!
 
-> > > > > > > Stashed changes
-
-If you want to keep learning about The Graph, we have more advanced tutorial on [Figment Learn](https://learn.figment.io/protocols/thegraph).
+If you want to keep learning about The Graph, we have more advanced tutorials on [Figment Learn](https://learn.figment.io/protocols/thegraph).

--- a/markdown/the_graph/SUBGRAPH_QUERY.md
+++ b/markdown/the_graph/SUBGRAPH_QUERY.md
@@ -4,9 +4,19 @@ After deploying the subgraph, we need to wait a little in order for it to sync w
 
 We can follow the progression of the sync looking at the logged output by the running docker instance of our local graph node.
 
+<<<<<<< Updated upstream
+
 > Before, running the query you'll need to check you have a [metamask](https://metamask.io/) extension installed with your browser and you're connected to the mainnet of Ethereum. Why? We'll decorate the date returned by the GraphQL query with data coming from the [CryptoPunks Data](https://etherscan.io/address/0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2#readContract) to be able to render the images and other punk metadata.
 
-Our Graph node come up with a GraphQL endpoint, available at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks/graphql). Open this in another tab and you will see a GraphiQL UI. Consider this a sandboz in which to experiment with queries. Open the right sidebar to explore your schema.
+# Our Graph node come up with a GraphQL endpoint, available at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks/graphql). Open this in another tab and you will see a GraphiQL UI. Consider this a sandboz in which to experiment with queries. Open the right sidebar to explore your schema.
+
+> Before, running the query you'll need to check you have a [metamask](https://metamask.io/) extension installed with your browser and you're connected to the mainnet of Ethereum. Why? We'll decorate the data returned by the GraphQL query with data coming from the [CryptoPunks Data](https://etherscan.io/address/0x16F5A35647D6F03D5D3da7b35409D65ba03aF3B2#readContract) to be able to render the images and other punk metadata.
+
+Our Graph node comes with a GraphQL endpoint, available at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks/graphql). Open this in another tab and you will see a GraphiQL UI. Consider this a sandbox in which to experiment with queries. Open the right sidebar to explore your schema.
+
+If you're running the Pathway using Gitpod, you will need to add the Gitpod Workspace URL to `.env.local` instead of localhost. The port number must also be added to the beginning of the URL, rather than at the end. For example: `https://8000-olive-meerkat-mapxxnyp.ws-us18.gitpod.io/`.
+
+> > > > > > > Stashed changes
 
 ## 👨‍💻 Your turn! Write the GraphQL query
 
@@ -18,7 +28,12 @@ Some hints to help you:
 - You will want `id`, `index`, `value` and `date`
 - Then use `first`, `orderBy` and `orderDirection` to get 10 of highest value
 
+<<<<<<< Updated upstream
 Remember to use **GraphiQL IDE** at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks) to play around
+=======
+Remember to use **GraphiQL IDE** at [http://localhost:8000/subgraphs/name/punks](http://localhost:8000/subgraphs/name/punks) (or at your Gitpod URL) to play around
+
+> > > > > > > Stashed changes
 
 ## 😅 Solution
 
@@ -49,6 +64,11 @@ Now, it's time to enjoy the result of your work! Click on the button on the righ
 
 Nice, you made it! What did you think?
 
+<<<<<<< Updated upstream
 If you have any feedback, reach out on [Discord](https://discord.com/invite/fszyM7K)!
+=======
+If you have any feedback, reach out on [Discord](https://figment.io/devchat)!
+
+> > > > > > > Stashed changes
 
 If you want to keep learning about The Graph, we have more advanced tutorial on [Figment Learn](https://learn.figment.io/protocols/thegraph).


### PR DESCRIPTION

- Add instructions to "Implement the mappings" about the Gitpod workspace URL
  - Fixed the description of the button to be clicked in "Make sure it works" (line 166).
<img width="1904" alt="Screen Shot 2021-10-31 at 9 23 51 PM" src="https://user-images.githubusercontent.com/2707197/139617463-6ba5366b-595e-4822-b084-f7a26965610f.png">

- Added mention regarding Gitpod to "Query the subgraph":
<img width="1904" alt="Screen Shot 2021-10-31 at 9 34 21 PM" src="https://user-images.githubusercontent.com/2707197/139618221-ee31f466-32e7-4874-b4a3-c5ff007010b0.png">

- Clean up typos, grammar and punctuation