### PR TITLE
make cluster selection work again

### DIFF
--- a/components/protocols/solana/components/nav/index.tsx
+++ b/components/protocols/solana/components/nav/index.tsx
@@ -7,8 +7,9 @@ import {
   getCurrentChainId,
   useGlobalState,
   getNetworkForCurrentChain,
-  isFirstStepForCurrentStepId,
   getFirstStepIdForCurrentChain,
+  getCurrentStepIdForCurrentChain,
+  isConnectionStep,
 } from 'context';
 import {PROTOCOL_INNER_STATES_ID, SOLANA_NETWORKS} from 'types';
 import {getSolanaInnerState} from '@figment-solana/lib';
@@ -103,6 +104,8 @@ const Nav = () => {
     });
   };
 
+  console.log('here', getCurrentStepIdForCurrentChain(state));
+
   return (
     <StepMenuBar>
       <Popover content={AppState} placement="bottom">
@@ -112,7 +115,7 @@ const Nav = () => {
         defaultValue={getNetworkForCurrentChain(state) as SOLANA_NETWORKS}
         style={{width: 120}}
         onChange={toggleLocal}
-        disabled={!isFirstStepForCurrentStepId(state)}
+        disabled={!isConnectionStep(state)}
       >
         <Option value={SOLANA_NETWORKS.DATAHUB}>Datahub</Option>
         <Option value={SOLANA_NETWORKS.DEVNET}>Devnet</Option>

--- a/context/index.tsx
+++ b/context/index.tsx
@@ -360,6 +360,13 @@ export const isCompletedForCurrentStepId = (state: GlobalStateT) => {
   return isCompleted;
 };
 
+export const isConnectionStep = (state: GlobalStateT) => {
+  return (
+    getCurrentStepIdForCurrentChain(state) ===
+    PROTOCOL_STEPS_ID.CHAIN_CONNECTION
+  );
+};
+
 // Inner state functions
 export const getChainInnerState = (
   state: GlobalStateT,


### PR DESCRIPTION
Enable the cluster selection dropdown on the Solana pathway during Connect step

https://linear.app/figment-learn/issue/LEA-434/enable-the-cluster-selection-dropdown-on-solana-pathway-durring