### PR TITLE
Update The Graph project setup to include .env.local

### DIFF
--- a/markdown/the_graph/PROJECT_SETUP.md
+++ b/markdown/the_graph/PROJECT_SETUP.md
@@ -25,6 +25,11 @@ To get an Alchemy API key, [create an account](https://www.alchemy.com/), then c
 
 ![Alchemy](https://raw.githubusercontent.com/figment-networks/learn-web3-dapp/main/markdown/__images__/the-graph/alchemy-view-api-key.png)
 
+Speaking of API keys, it's important to remember that Next.js reads from the file `.env.local` to determine which environment variables to use!
+To be able to complete this Pathway, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
+
+> Easily duplicate the file with the terminal command `cp .env.example .env.local`!
+
 ---
 
 ## 🎥 Video Walkthrough

--- a/markdown/the_graph/SUBGRAPH_QUERY.md
+++ b/markdown/the_graph/SUBGRAPH_QUERY.md
@@ -24,7 +24,7 @@ Remember to use **GraphiQL IDE** at [http://localhost:8000/subgraphs/name/punks]
 
 ## 😅 Solution
 
-In `components/protocols/the_graph/graphql/index.ts` replace the GraphQL query with:
+In `components/protocols/the_graph/graphql/query.ts` replace the GraphQL query with:
 
 ```graphql
 // solution


### PR DESCRIPTION
- Without instructions about creating `.env.local`, users would get stuck on the Mappings step when checking the subgraph deployment.
  - Added instructions to the setup step, below the Alchemy API key instructions:
<img width="718" alt="Screen Shot 2021-11-03 at 2 34 05 PM" src="https://user-images.githubusercontent.com/2707197/140188566-c9c45f50-dca2-4f20-aa64-cbfa95805d99.png">
 
EDIT:

Second commit to update filename in the final step of the pathway (Was showing `components/protocols/the_graph/graphql/index.ts` where the file in the repo is `components/protocols/the_graph/graphql/query.ts`)