### PR TITLE
Change preview to browser tab

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ tasks:
 
 ports:
   - port: 3000
-    onOpen: open-preview
+    onOpen: open-browser
 
 vscode:
   extensions:

--- a/markdown/solana/PROJECT_SETUP.md
+++ b/markdown/solana/PROJECT_SETUP.md
@@ -1,6 +1,12 @@
 # 💻 Requirements
 
-Make sure you've installed the [Solana CLI](https://docs.solana.com/cli/install-solana-cli-tools)'s latest release.
+## 🤖 Gitpod
+
+You will need to [install the Solana CLI](https://docs.solana.com/cli/install-solana-cli-tools) in the Gitpod workspace to complete this Pathway.
+
+## 🐑 Local clone
+
+If you have cloned the `learn-web3-dapp` repository to your local machine:
 
 > 🪟 **Windows Users:** There are known compatibility issues with the Solana BPF toolchain. You will need to use the Windows Subsystem for Linux or Gitpod to compile Solana programs. Please refer to the [installation guide](https://docs.figment.io/network-documentation/extra-guides/solana-setup-for-windows) we have provided.
 >
@@ -38,7 +44,7 @@ DATAHUB_TEZOS_API_KEY=
 
 # 🤖 Using a Test Validator
 
-At some point it may be useful to run a Test Validator. For example, if can't get airdrops because the Devnet faucet is not working. To run a local Test Validator, use this command in its own terminal tab or window :
+At some point it may be necessary to run a Test Validator. For example, if you can't get airdrops because the Devnet faucet is not working. To run a local Test Validator you will need to have the Solana CLI installed. Use this command in its own terminal tab or window :
 
 ```text
 solana-test-validator


### PR DESCRIPTION
- Changes `onOpen` from open-preview to open-browser
  - This will open the Next.js development server UI in a browser tab instead of a tab in the Gitpod VS Code UI