### PR TITLE
Secretjs supernova updates

### DIFF
--- a/components/protocols/secret/components/nav/index.tsx
+++ b/components/protocols/secret/components/nav/index.tsx
@@ -73,7 +73,7 @@ const Nav = () => {
     });
     dispatch({
       type: 'SetNetwork',
-      network: 'holodeck-2',
+      network: 'supernova-2',
     });
     trackStorageCleared('secret');
   };

--- a/components/protocols/secret/components/steps/Account.tsx
+++ b/components/protocols/secret/components/steps/Account.tsx
@@ -86,7 +86,7 @@ const Account = () => {
             <Alert
               message={
                 <a
-                  href={`https://faucet.secrettestnet.io/`}
+                  href={`https://faucet.supernova.enigma.co/`}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/components/protocols/secret/context/index.ts
+++ b/components/protocols/secret/context/index.ts
@@ -17,7 +17,7 @@ type Action =
 
 const initialState = {
   index: 0,
-  network: 'holodeck-2',
+  network: 'supernova-2',
 };
 
 function appStateReducer(state: State, action: Action): State {

--- a/components/protocols/secret/lib/index.ts
+++ b/components/protocols/secret/lib/index.ts
@@ -14,7 +14,7 @@ export const contractsUrl = (hash: string) =>
   `https://secretnodes.com/secret/chains/supernova-2/contracts/${hash}`;
 
 export const getSecretTestnetUrl = () => {
-  return 'http://bootstrap.supernova.enigma.co/';
+  return 'https://chainofsecrets.secrettestnet.io/';
 };
 
 export const getSafeUrl = async (force = true): Promise<string> => {

--- a/components/protocols/secret/lib/index.ts
+++ b/components/protocols/secret/lib/index.ts
@@ -8,13 +8,13 @@ export const getDataHubSecretNodeUrl = (network: SECRET_NETWORKS): string => {
 };
 
 export const transactionUrl = (hash: string) =>
-  `https://secretnodes.com/secret/chains/holodeck-2/transactions/${hash}`;
+  `https://secretnodes.com/secret/chains/supernova-2/transactions/${hash}`;
 
 export const contractsUrl = (hash: string) =>
-  `https://secretnodes.com/secret/chains/holodeck-2/contracts/${hash}`;
+  `https://secretnodes.com/secret/chains/supernova-2/contracts/${hash}`;
 
 export const getSecretTestnetUrl = () => {
-  return 'https://chainofsecrets.secrettestnet.io/';
+  return 'http://bootstrap.supernova.enigma.co/';
 };
 
 export const getSafeUrl = async (force = true): Promise<string> => {

--- a/markdown/secret/CHAIN_CONNECTION.md
+++ b/markdown/secret/CHAIN_CONNECTION.md
@@ -48,7 +48,7 @@ try {
 
 **What happened in the code above?**
 
-- First, we instantiate a new `CosmWamClient` passing the url of the `holodeck-2` network.
+- First, we instantiate a new `CosmWamClient` passing the url of the `supernova-2` network.
 - Next, using the `nodeInfo` method of the rest client returns a `NodeInfoResponse`.
 - Inspecting the methods of our object will lead us naturally to reference the `application_version.version` property.
 - Finally, we send the `version` back to the client-side as JSON.

--- a/markdown/secret/DEPLOY_CONTRACT.md
+++ b/markdown/secret/DEPLOY_CONTRACT.md
@@ -10,7 +10,7 @@ If you want to learn more about Secret smart contracts, follow the [**Developing
 {% endhint %}
 
 {% hint style="danger" %}
-You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/holodeck-2)
+You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/supernova-2)
 {% endhint %}
 
 Before, focusing on the deployment instructions, let's take a look at some important global variables:

--- a/markdown/secret/GET_BALANCE.md
+++ b/markdown/secret/GET_BALANCE.md
@@ -1,4 +1,4 @@
-Now that you have created an account on the **Secret** `holodeck-2` network, and funded it using the faucet - We're going to check the balance of our account to make sure everything went alright.
+Now that you have created an account on the **Secret** `supernova-2` network, and funded it using the faucet - We're going to check the balance of our account to make sure everything went alright.
 
 {% hint style="info" %}
 The native token on the **Secret Network** is **SCRT**
@@ -38,7 +38,7 @@ In `pages/api/secret/balance.ts`, implement the default function. You must repla
 Still not sure how to do this? No problem! The solution is below so you don't get stuck.
 
 {% hint style="danger" %}
-You could experience some issues with the availability of the network. [**Click here to check the current status of `holodeck-2`**](https://secretnodes.com/secret/chains/holodeck-2)
+You could experience some issues with the availability of the network. [**Click here to check the current status of `supernova-2`**](https://secretnodes.com/secret/chains/supernova-2)
 {% endhint %}
 
 ---

--- a/markdown/secret/GET_CONTRACT_VALUE.md
+++ b/markdown/secret/GET_CONTRACT_VALUE.md
@@ -5,7 +5,7 @@ If you want to learn more about Secret smart contracts, follow the [**Developing
 {% endhint %}
 
 {% hint style="danger" %}
-You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/holodeck-2)
+You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/supernova-2)
 {% endhint %}
 
 Before focusing on retrieving a value from the smart contract, let's take a look at the fees object:

--- a/markdown/secret/SET_CONTRACT_VALUE.md
+++ b/markdown/secret/SET_CONTRACT_VALUE.md
@@ -5,7 +5,7 @@ If you want to learn more about Secret smart contracts, follow the [**Developing
 {% endhint %}
 
 {% hint style="danger" %}
-You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/holodeck-2)
+You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/supernova-2)
 {% endhint %}
 
 Before focusing on altering a value on the smart contract, let's take a look at the fees object:

--- a/markdown/secret/TRANSFER_TOKEN.md
+++ b/markdown/secret/TRANSFER_TOKEN.md
@@ -3,7 +3,7 @@ Of course, everyone likes to eat pizza, but among all available pizzas you prefe
 To do so, you'll need to make an encrypted transaction - in the **Secret** world everything is done with privacy in mind! Let's take a look at how to do this.
 
 {% hint style="danger" %}
-You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/holodeck-2)
+You could experience some issues with the availability of the network [**Click here to check the current status**](https://secretnodes.com/secret/chains/supernova-2)
 {% endhint %}
 
 ---

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-player": "^2.9.0",
     "react-syntax-highlighter": "^15.4.4",
     "remark-gfm": "^2.0.0",
-    "secretjs": "^0.16.1",
+    "secretjs": "^0.17.3",
     "simple-react-lightbox": "^3.6.9-0",
     "styled-components": "^5.3.0",
     "web3": "^1.5.0"

--- a/types/index.ts
+++ b/types/index.ts
@@ -94,7 +94,7 @@ export enum CELO_NETWORKS {
 
 export enum SECRET_NETWORKS {
   MAINNET = 'MAINNET',
-  TESTNET = 'HOLODECK-2',
+  TESTNET = 'SUPERNOVA-2',
   DATAHUB = 'datahub',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2369,6 +2369,59 @@
     "@types/websocket" "^1.0.4"
     websocket "^1.0.34"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@rushstack/eslint-patch@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.0.8.tgz#be3e914e84eacf16dbebd311c0d0b44aa1174c64"
@@ -2926,6 +2979,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.176.tgz#641150fc1cda36fbfa329de603bbb175d7ee20c0"
   integrity sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==
 
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
 "@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"
@@ -2977,6 +3035,11 @@
   version "11.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
+"@types/node@>=13.7.0":
+  version "16.11.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz#2e3ad0a680d96367103d3e670d41c2fed3da61ae"
+  integrity sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==
 
 "@types/node@^10.12.18":
   version "10.17.60"
@@ -8239,6 +8302,11 @@ logfmt@^1.3.2:
     split "0.2.x"
     through "2.3.x"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 longest-streak@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.0.0.tgz#f127e2bded83caa6a35ac5f7a2f2b2f94b36f3dc"
@@ -9873,6 +9941,25 @@ property-information@^6.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.0.1.tgz#7c668d9f2b9cb63bc3e105d8b8dfee7221a17800"
   integrity sha512-F4WUUAF7fMeF4/JUFHNBWDaKDXi2jbvqBW/y6o5wsf3j19wTZ7S60TmtB5HoBhtgw7NKQRMWuz5vk2PR0CygUg==
 
+protobufjs@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
+
 proxy-addr@~2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -10996,10 +11083,10 @@ secp256k1@^4.0.0, secp256k1@^4.0.1, secp256k1@^4.0.2:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
 
-secretjs@^0.16.1:
-  version "0.16.7"
-  resolved "https://registry.yarnpkg.com/secretjs/-/secretjs-0.16.7.tgz#8c816ddef476a1d7ac877f86807a037c249cedf0"
-  integrity sha512-HL2Ekui0TFQhWrzQ5IenI3a54IaD9UdXwdyYMMLhisQCm5/quMw/v4CxmjEro+b5FxlEYvWcgzFO6nntduywDg==
+secretjs@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/secretjs/-/secretjs-0.17.3.tgz#99483472a000b2feb946a2a9bc18561f2041a002"
+  integrity sha512-eB2+eKkGUdjoR+sBRbtJUglEaB3jwlcz69c28xT5+Y65d1cxMJzdx3cBR7cLnqWayyERidhzZL+idu9TrwQR9g==
   dependencies:
     "@iov/crypto" "2.1.0"
     "@iov/encoding" "2.1.0"
@@ -11010,6 +11097,7 @@ secretjs@^0.16.1:
     js-crypto-hkdf "0.7.3"
     miscreant "0.3.2"
     pako "1.0.11"
+    protobufjs "^6.11.2"
     secure-random "1.1.2"
 
 secure-random@1.1.2:


### PR DESCRIPTION
I can't test Figment's testnet with my free DataHub account to know if it's still on holodeck-2 or upgraded to supernova, but with these changes you can run a local docker container dev against supernova, or connect to the Scrt Labs bootstrap node with .env.local containing one of these URLs as appropriate

`#DATAHUB_SECRET_TESTNET_RPC_URL=http://bootstrap.supernova.enigma.co:1317
DATAHUB_SECRET_TESTNET_RPC_URL=localhost:1317`