### PR TITLE
Update wording in The Graph pathway defaultEntityStatus

### DIFF
--- a/components/protocols/the_graph/lib/index.tsx
+++ b/components/protocols/the_graph/lib/index.tsx
@@ -25,7 +25,7 @@ export const defaultManifestStatus: ManifestStepStatusesT = {
 export const defaultEntityStatus: EntityStepStatusesT = {
   entities: {
     isValid: false,
-    message: 'Numbers of entities mismatch',
+    message: 'Number of entities mismatch',
   },
   account: {
     isValid: false,


### PR DESCRIPTION
- The word "Numbers" in this case is confusing, as readers may interpret it to mean that the entities should contain numbers. Correcting it to "Number" will prevent users from misinterpreting it.

<img width="705" alt="Screen Shot 2021-12-05 at 9 38 40 AM" src="https://user-images.githubusercontent.com/2707197/144755197-192e13d4-3a38-42f8-8a8a-61e7b7d4ffe0.png">

