### PR TITLE
Improved polkadot pathway

### DIFF
--- a/components/protocols/polkadot/components/Account.tsx
+++ b/components/protocols/polkadot/components/Account.tsx
@@ -5,9 +5,9 @@ import axios from 'axios';
 import {PROTOCOL_INNER_STATES_ID} from 'types';
 import {useGlobalState} from 'context';
 
-const {Text} = Typography;
+import {FAUCET_URL} from '@figment-polkadot/lib';
 
-const FAUCET_URL = `https://app.element.io/#/room/#westend_faucet:matrix.org`;
+const {Text} = Typography;
 
 const Account = () => {
   const {dispatch} = useGlobalState();

--- a/components/protocols/polkadot/components/Balance.tsx
+++ b/components/protocols/polkadot/components/Balance.tsx
@@ -18,7 +18,7 @@ const Balance = () => {
   const [balance, setBalance] = useState<number | null>(null);
 
   useEffect(() => {
-    if (balance) {
+    if (balance !== null) {
       dispatch({
         type: 'SetIsCompleted',
       });
@@ -50,7 +50,7 @@ const Balance = () => {
         <Button type="primary" onClick={getBalance} loading={fetching}>
           Check Balance
         </Button>
-        {balance ? (
+        {balance !== null ? (
           <Alert
             message={
               <Text

--- a/components/protocols/polkadot/components/Balance.tsx
+++ b/components/protocols/polkadot/components/Balance.tsx
@@ -4,6 +4,8 @@ import axios from 'axios';
 import {useGlobalState} from 'context';
 import {getInnerState} from 'utils/context';
 
+import {FAUCET_URL} from '@figment-polkadot/lib';
+
 const {Text} = Typography;
 
 const DECIMAL_OFFSET = 10 ** 12;
@@ -18,7 +20,7 @@ const Balance = () => {
   const [balance, setBalance] = useState<number | null>(null);
 
   useEffect(() => {
-    if (balance !== null) {
+    if (balance !== null && balance > 0) {
       dispatch({
         type: 'SetIsCompleted',
       });
@@ -51,15 +53,33 @@ const Balance = () => {
           Check Balance
         </Button>
         {balance !== null ? (
-          <Alert
-            message={
-              <Text
-                strong
-              >{`This address has a balance of ${balance} ${TOKEN_SYMBOL}`}</Text>
-            }
-            type="success"
-            showIcon
-          />
+          <>
+            <Alert
+              message={
+                <Text
+                  strong
+                >{`This address has a balance of ${balance} ${TOKEN_SYMBOL}`}</Text>
+              }
+              type="success"
+              showIcon
+            />
+            {balance === 0 ? (
+              <Alert
+                message={
+                  <Space>
+                    <Text strong>Fund your account</Text>
+                  </Space>
+                }
+                description={
+                  <a href={FAUCET_URL} target="_blank" rel="noreferrer">
+                    Go to the faucet
+                  </a>
+                }
+                type="warning"
+                showIcon
+              />
+            ) : null}
+          </>
         ) : error ? (
           <Alert message={error} type="error" showIcon />
         ) : (

--- a/components/protocols/polkadot/lib/index.ts
+++ b/components/protocols/polkadot/lib/index.ts
@@ -11,3 +11,5 @@ export const accountExplorer = (network: string) => (address: string) =>
 
 export const transactionUrl = (hash: string) =>
   `https://westend.subscan.io/extrinsic/${hash}`;
+
+export const FAUCET_URL = `https://app.element.io/#/room/#westend_faucet:matrix.org`;


### PR DESCRIPTION
1. Don't pass user to check existential deposit if balance is zero and warn to navigate to faucet and get token
2. Since balance was checking by it's boolean representation, error were displayed even if zero balance were returned from API. Now only `null` balance is causing error message. Zero balance warns about necessary of getting token from the faucet