### PR TITLE
Update context.ts

### DIFF
--- a/utils/context.ts
+++ b/utils/context.ts
@@ -49,7 +49,7 @@ export const prepareGlobalState = (
       const newSteps = stepsId.reduce((steps, stepId) => {
         steps[stepId] = {
           ...steps[stepId],
-          ...(localStorage ? localStorage[chain].steps[stepId] : {}),
+          ...(localStorage ? localStorage[chain]?.steps[stepId] : {}),
         };
         return steps;
       }, protocols[chain].steps);


### PR DESCRIPTION
This issue cannot be reproduced on gitpod env as the local storage is cleared each time a user starts a new session. Then there is no staled state to manage.

If you want to reproduce the issue before the fix does as follow:
- Clone the repo
- Checkout to with-solution
- Navigate to NEAR advance click and next step one time
- Checkout to main
- Click on NEAR-GRAPH

Result => the staled state will crash the app
![Screenshot_20220101_125814](https://user-images.githubusercontent.com/529836/147850026-93060fba-1260-453d-b2f6-17dbdd5171ff.png)



