### PR TITLE
Revert "Update context.ts"

### DIFF
--- a/utils/context.ts
+++ b/utils/context.ts
@@ -49,7 +49,7 @@ export const prepareGlobalState = (
       const newSteps = stepsId.reduce((steps, stepId) => {
         steps[stepId] = {
           ...steps[stepId],
-          ...(localStorage ? localStorage[chain]?.steps[stepId] : {}),
+          ...(localStorage ? localStorage[chain].steps[stepId] : {}),
         };
         return steps;
       }, protocols[chain].steps);


### PR DESCRIPTION
Ok, the first path adressed the first bug.
For the second bug I found I scenario to reproduce it:

Scenario:
- `git clone git@github.com:figment-networks/learn-web3-dapp.git  lw3d`
- `cd lw3d`
- `git checkout -b old-sys 1e68f34979819694c2dcec2cce620607626475cd`
- Open browser 
- Clear local storage
- Open a protocol, NEAR for example
- Go back to the home page (localhost:3000)
- Go back to the terminal
- `git checkout main`
- Go back to browser
- Open GRAPH-NEAR

And you have your bug =)

Here we have a very, old staled state....

Try to reproduce it with this branch in place of the main branch, and normaly the bug should has disappear.

Good test