### PR TITLE
Add hint about build-essential

### DIFF
--- a/markdown/solana/DEPLOY_CONTRACT.md
+++ b/markdown/solana/DEPLOY_CONTRACT.md
@@ -191,6 +191,10 @@ This step can take a few minutes!
 yarn run solana:build:program
 ```
 
+{% hint style="tip" %}
+If you have cloned the reo locally and you are using WSL or Linux, you might get an **error: linker `cc` not found** when compiling the Solana program. You will need to install the **build-essential** package by running `sudo apt install build-essential`, or the install command for your specific Linux distribution.
+{% endhint %}
+
 When it's successful, you will see the instructions to execute the deploy command with the path to the compiled program named `helloworld.so`. While this would work, we want to specify the keypair we generated just for this purpose, so read on.
 
 ```text


### PR DESCRIPTION
- Added hint to the Deploy step regarding the **build-essential** package in response to the error "linker 'cc' not found".
<img width="720" alt="Screen Shot 2022-01-10 at 8 09 08 AM" src="https://user-images.githubusercontent.com/2707197/148788815-f6de8449-1ed4-4696-b5b6-0964a952d0ee.png">
