### PR TITLE
Add CLI install hint

### DIFF
--- a/docker/docker-compose-near.yml
+++ b/docker/docker-compose-near.yml
@@ -17,7 +17,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: '${ETHEREUM_RPC:-localhost:http://host.docker.internal:8545}'
+      near: '${ETHEREUM_RPC:-mainnet:https://rpc.mainnet.near.org}'
       RUST_LOG: info
       GRAPH_LOG: info
   ipfs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      near: '${ETHEREUM_RPC:-mainnet:https://rpc.mainnet.near.org}'
+      ethereum: '${ETHEREUM_RPC:-localhost:http://host.docker.internal:8545}'
       RUST_LOG: info
       GRAPH_LOG: info
   ipfs:

--- a/markdown/the_graph/SUBGRAPH_SCAFFOLD.md
+++ b/markdown/the_graph/SUBGRAPH_SCAFFOLD.md
@@ -26,6 +26,10 @@ In a code editor, a subgraph will be a folder with a few different folders and f
 yarn global add @graphprotocol/graph-cli
 ```
 
+{% hint style="tip" %}
+If you're using Gitpod, Yarn won't automatically add the CLI binary to your PATH - use `npm install -g @graphprotocol/graph-cli` instead!
+{% endhint %}
+
 Verify the installation was successful by running `graph` in your Terminal. You should see:
 
 ```text


### PR DESCRIPTION
Gitpod doesn't like how Yarn does global installs, so we can add a hint to Gitpod users to use `npm install -g` instead.

EDIT: 

The additional commit for `docker-compose.yaml` is because during the PR for the Graph + NEAR pathway, the file was changed incorrectly, which led to The Graph pathway being broken for the `yarn deploy-local` step -

See: https://github.com/VitalPointAI/learn-web3-dapp/blob/bf3f2bc47ca38d89ecd5064cf72984ae2e750cf3/docker/docker-compose-near.yml <-- Incorrectly has `ethereum: '${ETHEREUM_RPC:-localhost:http://host.docker.internal:8545}'`

Also: https://github.com/VitalPointAI/learn-web3-dapp/blob/bf3f2bc47ca38d89ecd5064cf72984ae2e750cf3/docker/docker-compose.yml <-- Incorrectly has `near: '${ETHEREUM_RPC:-mainnet:https://rpc.mainnet.near.org}'`