### PR TITLE
near and the graph docker compose had been switched

### DIFF
--- a/docker/docker-compose-near.yml
+++ b/docker/docker-compose-near.yml
@@ -17,7 +17,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: '${ETHEREUM_RPC:-localhost:http://host.docker.internal:8545}'
+      near: '${ETHEREUM_RPC:-mainnet:https://rpc.mainnet.near.org}'
       RUST_LOG: info
       GRAPH_LOG: info
   ipfs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      near: '${ETHEREUM_RPC:-mainnet:https://rpc.mainnet.near.org}'
+      ethereum: '${ETHEREUM_RPC:-localhost:http://host.docker.internal:8545}'
       RUST_LOG: info
       GRAPH_LOG: info
   ipfs:


### PR DESCRIPTION
It seems the near and the graph compose files have been inverted.

In TheGraph tutorial it says to run `docker-compose up` which ran the near version.

It seems the near tutorial is relying on the hosted service for now so I guess this is ok to keep the graph docker compose as the main compose file?

Cheers 🍺