### PR TITLE
Update DataHub signup links

### DIFF
--- a/markdown/avalanche/PROJECT_SETUP.md
+++ b/markdown/avalanche/PROJECT_SETUP.md
@@ -1,6 +1,6 @@
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Avalanche via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Avalanche via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/celo/PROJECT_SETUP.md
+++ b/markdown/celo/PROJECT_SETUP.md
@@ -1,6 +1,6 @@
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Celo via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Celo via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/near/PROJECT_SETUP.md
+++ b/markdown/near/PROJECT_SETUP.md
@@ -1,6 +1,6 @@
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access NEAR via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access NEAR via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/polkadot/PROJECT_SETUP.md
+++ b/markdown/polkadot/PROJECT_SETUP.md
@@ -1,6 +1,6 @@
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Polkadot via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Polkadot via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/polygon/PROJECT_SETUP.md
+++ b/markdown/polygon/PROJECT_SETUP.md
@@ -39,7 +39,7 @@ We use the testnet for development before moving into production on the main net
 
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Polygon via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Polygon via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/secret/PROJECT_SETUP.md
+++ b/markdown/secret/PROJECT_SETUP.md
@@ -1,6 +1,6 @@
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Secret via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Secret via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/solana/PROJECT_SETUP.md
+++ b/markdown/solana/PROJECT_SETUP.md
@@ -15,7 +15,7 @@ If you cloned the `learn-web3-dapp` repo locally, pay attention to the following
 
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Solana via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Solana via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 

--- a/markdown/tezos/PROJECT_SETUP.md
+++ b/markdown/tezos/PROJECT_SETUP.md
@@ -1,6 +1,6 @@
 # 🧩 DataHub API keys
 
-To make use of the Pathway content, you will require a DataHub account and a valid API key to access Tezos via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub.figment.io/sign_up) and verify your email address.
+To make use of the Pathway content, you will require a DataHub account and a valid API key to access Tezos via DataHub's infrastructure. [Sign up for a DataHub account](https://datahub-beta.figment.io/signup) and verify your email address.
 
 To use your API key, you must create a new file named `.env.local` in the project root directory: `/learn-web3-dapp/.env.local`, copying the contents of the existing `.env.example` file.
 


### PR DESCRIPTION
The previous link <https://datahub.figment.io/sign_up> redirects to <https://datahub-beta.figment.io> instead of <https://datahub-beta.figment.io/signup> which is confusing to users. Several clicks are needed from the front page to get to the signup form. We can alter the links again when the DataHub pages stabilize.