### PR TITLE
Remove Gitpod note for devnet deployments

### DIFF
--- a/markdown/polygon/TRANSFER_TOKEN.md
+++ b/markdown/polygon/TRANSFER_TOKEN.md
@@ -82,7 +82,7 @@ Still not sure how to do this? No problem! The solution is below so you don't ge
 
 # ✅ Make sure it works
 
-Once the code in `components/protocols/polygon/challenges/Transfer.tsx` is complete, enter an amount to transfer and click **Transfer** to send tokens to another Polygon account.
+Once the code in `components/protocols/polygon/challenges/transfer.ts` is complete, enter an amount to transfer and click **Transfer** to send tokens to another Polygon account.
 
 ---
 

--- a/markdown/polygon/TRANSFER_TOKEN.md
+++ b/markdown/polygon/TRANSFER_TOKEN.md
@@ -5,7 +5,7 @@ Transferring some token is one of the major feature of Web 3. In this challenge,
 # 🏋️ Challenge
 
 {% hint style="tip" %}
-**Imagine this scenario:** You know you have a big balance and you want to eat some pizza. Then, you need to transfer **0.1** MATIC to buy one! In `components/protocols/polygon/challenges/Transfer.tsx`, implement the `transfer` function.
+**Imagine this scenario:** You know you have a big balance and you want to eat some pizza. Then, you need to transfer **0.1** MATIC to buy one! In `components/protocols/polygon/challenges/transfer.ts`, implement the `transfer` function.
 {% endhint %}
 
 **Take a few minutes to figure this out.**

--- a/markdown/solana/DEPLOY_CONTRACT.md
+++ b/markdown/solana/DEPLOY_CONTRACT.md
@@ -234,10 +234,6 @@ Program Id: 7KwpCaaYXRsjfCTvf85eCVuZDW894zZNN38UMxMpQoaQ
 
 ## ⛓ Deploying the program to a test validator inside Gitpod
 
-{% hint style="info" %}
-Gitpod currently has an issue which prevents deployments to devnet. To work around this, you will need to run a test validator inside of Gitpod, and deploy your program there instead of devnet. Follow the steps below to complete this step using this alternative method. **Users who have cloned the repository locally are unaffected by this issue**.
-{% endhint %}
-
 First, you will need to change the Solana CLI target cluster with the terminal command:
 
 ```text


### PR DESCRIPTION
As per https://github.com/gitpod-io/gitpod/issues/7830 the ability to deploy programs from inside Gitpod workspaces has been restored. Removing the note about using a test validator as a workaround.