### PR TITLE
Update the link of Solana CLI to v1.10.25

### DIFF
--- a/markdown/solana/DEPLOY_CONTRACT.md
+++ b/markdown/solana/DEPLOY_CONTRACT.md
@@ -130,7 +130,7 @@ source $HOME/.cargo/env
 [**Install the Solana CLI**](https://docs.solana.com/cli/install-solana-cli-tools):
 
 ```text
-sh -c "$(curl -sSfL https://release.solana.com/v1.8.5/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v1.10.25/install)"
 ```
 
 ---


### PR DESCRIPTION
It seems that Solana CLI v1.8.5 is outdated and installer cannot work longer.

---

When I run `sh -c "$(curl -sSfL https://release.solana.com/v1.8.5/install)"`,
I got this error:
```
downloading v1.8.5 installer
Error: Unknown release: 1.8.5
```

After I changed v1.8.5 to v1.10.25  (the latest version), the problem go away.

the newer version works fine.