### PR TITLE
update graph-node docker version from 0.24.1 to 0.26.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   graph-node:
-    image: graphprotocol/graph-node:v0.24.1
+    image: graphprotocol/graph-node:v0.26.0
     ports:
       - '8000:8000'
       - '8001:8001'


### PR DESCRIPTION
Deploying the subgraph fails with :
```
This Graph Node only supports manifest spec versions between 0.0.2 and 0.0.3, but subgraph QmZjVjGixgPnDZWyhNEqheFiAsX4oWMSdj6cY7Rx1RtVn6 uses `0.0.4`
```

 due to the compiling process bumping the specVersion from the specified 0.0.2 to 0.0.4 
```
Bump manifest specVersion from 0.0.2 to 0.0.4
```

Updating the docker container to the newest version `v0.26.0`, from `v.0.24.1` allows for schema 0.0.4 and also allows for the rest of the pathway to be completed successfully.

```
Deployed to http://localhost:8000/subgraphs/name/punks/graphql

Subgraph endpoints:
Queries (HTTP):     http://localhost:8000/subgraphs/name/punks
```