### PR TITLE
Fix styledComponents warning on server start

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ module.exports = withTM({
   typescript: {
     ignoreBuildErrors: true,
   },
-  experimental: {
+  compiler: {
     // Enables the styled-components SWC transform
     styledComponents: true,
   },


### PR DESCRIPTION
- Fixes the warning "warn  - `styledComponents` has been moved out of `experimental` and into `compiler`. Please update your next.config.js file accordingly." on development server startup.